### PR TITLE
Fix: Resolve PDF processing and LLM errors

### DIFF
--- a/pdf_parser.py
+++ b/pdf_parser.py
@@ -6,10 +6,6 @@ from PIL import Image
 import numpy as np
 import cv2
 import logging
-import streamlit as st  # Added for Streamlit UI
-
-# Set Streamlit page configuration
-st.set_page_config(page_title="PDF Parser and Content Extractor", layout="wide")
 
 # Assuming your config.py is in the same directory or accessible in PYTHONPATH
 import config
@@ -17,16 +13,6 @@ import config
 # Configure logging
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=config.LOG_LEVEL, format=config.LOG_FORMAT)
-
-# Streamlit UI setup
-st.title("PDF Parser and Content Extractor")
-st.sidebar.header("PDF Processing Logs")
-log_placeholder = st.sidebar.empty()  # Placeholder for logs
-content_placeholder = st.empty()  # Placeholder for extracted content
-
-def log_to_streamlit(message):
-    """Helper function to log messages to Streamlit UI."""
-    log_placeholder.text(message)
 
 def convert_pdf_page_to_image(pdf_path, page_num, dpi=config.PDF_TO_IMAGE_DPI):
     """Converts a single page of a PDF to a PIL Image."""
@@ -36,7 +22,6 @@ def convert_pdf_page_to_image(pdf_path, page_num, dpi=config.PDF_TO_IMAGE_DPI):
             return images[0]
     except Exception as e:
         logger.error(f"Error converting page {page_num} of PDF '{pdf_path}' to image: {e}")
-        log_to_streamlit(f"Error converting page {page_num} of PDF '{pdf_path}' to image: {e}")
     return None
 
 def pil_to_cv2(pil_image):
@@ -48,36 +33,29 @@ def extract_content_from_pdf(pdf_path, table_detector_pipeline, ocr_reader):
     Extracts structured content (text and tables) from a single PDF file.
     """
     logger.info(f"Opening PDF file: {pdf_path}")
-    log_to_streamlit(f"Opening PDF file: {pdf_path}")
     extracted_pdf_data = []
     try:
         doc = fitz.open(pdf_path)
     except Exception as e:
         logger.error(f"Error opening PDF '{pdf_path}': {e}")
-        log_to_streamlit(f"Error opening PDF '{pdf_path}': {e}")
         return extracted_pdf_data
 
     for page_num in range(len(doc)):
         logger.info(f"Processing page {page_num + 1}/{len(doc)} of PDF: {pdf_path}")
-        log_to_streamlit(f"Processing page {page_num + 1}/{len(doc)} of PDF: {pdf_path}")
         current_page_data = {"page_number": page_num + 1, "source_pdf": os.path.basename(pdf_path), "content": []}
 
         try:
             pil_image = convert_pdf_page_to_image(pdf_path, page_num, dpi=config.PDF_TO_IMAGE_DPI)
             if not pil_image:
                 logger.warning(f"Could not convert page {page_num + 1} of '{pdf_path}' to image. Skipping page.")
-                log_to_streamlit(f"Could not convert page {page_num + 1} of '{pdf_path}' to image. Skipping page.")
                 extracted_pdf_data.append(current_page_data)
                 continue
 
             logger.info(f"Running table detection on page {page_num + 1}...")
-            log_to_streamlit(f"Running table detection on page {page_num + 1}...")
             table_detections = table_detector_pipeline(pil_image)
             logger.info(f"Detected {len(table_detections)} potential tables on page {page_num + 1}.")
-            log_to_streamlit(f"Detected {len(table_detections)} potential tables on page {page_num + 1}.")
 
             logger.info(f"Running OCR on non-table regions of page {page_num + 1}...")
-            log_to_streamlit(f"Running OCR on non-table regions of page {page_num + 1}...")
             img_np_rgb = np.array(pil_image)
             non_table_mask = np.ones(img_np_rgb.shape[:2], dtype=np.uint8) * 255
             for detection in table_detections:
@@ -92,7 +70,6 @@ def extract_content_from_pdf(pdf_path, table_detector_pipeline, ocr_reader):
             non_table_img_np = cv2.bitwise_and(img_np_rgb, img_np_rgb, mask=non_table_mask)
             non_table_ocr_results = ocr_reader.readtext(non_table_img_np, paragraph=True)
             logger.info(f"Extracted {len(non_table_ocr_results)} text blocks from non-table regions on page {page_num + 1}.")
-            log_to_streamlit(f"Extracted {len(non_table_ocr_results)} text blocks from non-table regions on page {page_num + 1}.")
 
             for ocr_result in non_table_ocr_results:
                 if len(ocr_result) >= 2:
@@ -100,7 +77,6 @@ def extract_content_from_pdf(pdf_path, table_detector_pipeline, ocr_reader):
                     current_page_data["content"].append({"type": "plain_text", "text": text})
 
             logger.info(f"Running OCR on detected tables on page {page_num + 1}...")
-            log_to_streamlit(f"Running OCR on detected tables on page {page_num + 1}...")
             for detection in table_detections:
                 if detection['label'] == 'table':
                     box = detection['box']
@@ -108,48 +84,22 @@ def extract_content_from_pdf(pdf_path, table_detector_pipeline, ocr_reader):
                     table_image = pil_image.crop((x0, y0, x1, y1))
                     table_ocr_results = ocr_reader.readtext(np.array(table_image))
                     table_text = [result[1] for result in table_ocr_results]
-                    current_page_data["content"].append({"type": "table", "text": table_text})
+                    current_page_data["content"].append({
+                        "type": "table",
+                        "extracted_text_list": table_text,
+                        "is_at_page_top": False,
+                        "is_at_page_bottom": False
+                    })
 
         except Exception as e:
             logger.error(f"Error processing page {page_num + 1} of PDF '{pdf_path}': {e}", exc_info=True)
-            log_to_streamlit(f"Error processing page {page_num + 1} of PDF '{pdf_path}': {e}")
 
         extracted_pdf_data.append(current_page_data)
         logger.info(f"Page {page_num + 1} content items: {len(current_page_data['content'])}")
-        log_to_streamlit(f"Page {page_num + 1} content items: {len(current_page_data['content'])}")
-        content_placeholder.json(current_page_data)  # Display extracted content in Streamlit UI
     
     doc.close()
     logger.info(f"Finished processing PDF: {pdf_path}")
-    log_to_streamlit(f"Finished processing PDF: {pdf_path}")
     return extracted_pdf_data
-
-def group_content_into_contextual_blocks(extracted_data):
-    """
-    Groups extracted content into contextual blocks based on page numbers or content types.
-    """
-    logger.info("Grouping extracted content into contextual blocks...")
-    contextual_blocks = []
-
-    for page_data in extracted_data:
-        if not page_data["content"]:
-            logger.warning(f"No content found on page {page_data['page_number']} of {page_data['source_pdf']}. Skipping.")
-            continue
-
-        # Example grouping logic: Group all content from a single page into one block
-        block = {
-            "page_number": page_data["page_number"],
-            "source_pdf": page_data["source_pdf"],
-            "content": page_data["content"]
-        }
-        contextual_blocks.append(block)
-
-    if contextual_blocks:
-        logger.info(f"Created {len(contextual_blocks)} contextual blocks.")
-    else:
-        logger.warning("No contextual blocks created from extracted data.")
-    
-    return contextual_blocks
 
 if __name__ == '__main__':
     import os
@@ -206,14 +156,9 @@ if __name__ == '__main__':
                     if content_item['type'] == 'plain_text':
                         logger.info(f"      Text: {content_item['text'][:100]}...")
                     elif content_item['type'] == 'table':
-                        logger.info(f"      Table Text List: {content_item['text']}")
-
-            # Group extracted content into contextual blocks
-            contextual_blocks = group_content_into_contextual_blocks(structured_data)
-            if contextual_blocks:
-                logger.info("Contextual blocks created successfully.")
-            else:
-                logger.warning("No contextual blocks created from extracted data.")
+                        logger.info(f"      Table Extracted Text List: {content_item['extracted_text_list']}")
+                        logger.info(f"      Is at page top: {content_item['is_at_page_top']}")
+                        logger.info(f"      Is at page bottom: {content_item['is_at_page_bottom']}")
         else:
             logger.error(f"No data extracted from {example_pdf_path}.")
     else:


### PR DESCRIPTION
This commit addresses two primary issues:
1. PDF processing failed to create contextual blocks due to a mismatch in data structure between `pdf_parser.py` and `vector_indexer.py`.
2. Queries to the language model resulted in a generic error, likely due to the lack of context from the failed PDF processing.

Changes:
- Modified `pdf_parser.py` (`extract_content_from_pdf`):
    - Renamed table content key from `text` to `extracted_text_list`.
    - Added `is_at_page_top` and `is_at_page_bottom` keys (defaulted to `False`) to table content items to match the structure expected by `vector_indexer.py`.
- Removed the redundant `group_content_into_contextual_blocks` function from `pdf_parser.py` to avoid confusion.
- Cleaned up Streamlit UI elements (imports, function calls) from `pdf_parser.py`, making it a general-purpose module.

These changes ensure that PDF content is parsed and structured correctly, allowing contextual blocks to be generated, the FAISS index to be built, and the language model to receive appropriate context for answering your queries.